### PR TITLE
Refactoring of validations

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -48,6 +48,7 @@ function Strategy(bewit, verify) {
   if (!verify) throw new Error('HTTP Hawk authentication strategy requires a verify function');
   this.verify = verify;
   this.bewit = bewit;
+  passport.Strategy.call(this);
 }
 
 /**
@@ -69,18 +70,16 @@ Strategy.prototype.authenticate = function(req) {
 
   if(this.bewit){
     hawk.uri.authenticate(req, this.verify, {}, function (err, credentials, ext) {
-      if (err && err.message === 'Missing credentials') return this.fail('invalid_token');
-      if (err && err.message) return this.fail(err.message);
       if (err && err.isMissing) return this.error(new Error('Missing authentication tokens'));
-      if (err) return this.error(err);
+      if (err && err.message === 'Missing credentials') return this.error(new Error('Invalid authentication tokens'));
+      if (err && err.message) return this.error(new Error(err.message)); // Return hawk error
       this.success(credentials.user, ext);
     }.bind(this));
   }else{
     hawk.server.authenticate(req, this.verify, {}, function (err, credentials, ext) {
-      if (err && err.message === 'Missing credentials') return this.fail('invalid_token');
-      if (err && err.message) return this.fail(err.message);
       if (err && err.isMissing) return this.error(new Error('Missing authentication tokens'));
-      if (err) return this.error(err);      
+      if (err && err.message === 'Missing credentials') return this.error(new Error('Invalid authentication tokens'));
+      if (err && err.message) return this.error(new Error(err.message)); // Return hawk error
       this.success(credentials.user, ext);
     }.bind(this));
   }

--- a/test/bewit.tests.js
+++ b/test/bewit.tests.js
@@ -31,7 +31,7 @@ describe('passport-hawk with bewit', function() {
       testDone();
     };
 
-    strategy.fail = strategy.error = function() {
+    strategy.error = function() {
       testDone(new Error(arguments));
     };
     strategy.authenticate(req);
@@ -46,8 +46,8 @@ describe('passport-hawk with bewit', function() {
       method: 'GET',
       url: '/resource/4?filter=a&bewit=' + bewit  
     };
-    strategy.fail = function(challenge) {
-      challenge.should.eql('Bad mac');
+    strategy.error = function(challenge) {      
+      challenge.message.should.eql('Bad mac');
       testDone();
     };
     strategy.authenticate(req);
@@ -68,8 +68,8 @@ describe('passport-hawk with bewit', function() {
       url: '/resource/4?filter=a&bewit=' + bewit  
     };
 
-    strategy.fail = function(challenge) {
-      challenge.should.eql('Unknown credentials');
+    strategy.error = function(challenge) {
+      challenge.message.should.eql('Unknown credentials');
       testDone();
     };
     strategy.authenticate(req);

--- a/test/header.tests.js
+++ b/test/header.tests.js
@@ -28,10 +28,6 @@ describe('passport-hawk', function() {
       user.should.eql('tito');
       testDone();
     };
-    strategy.error = function() {
-      console.log('alskjhslkhskjdhf');
-      testDone(arguments);
-    };
     strategy.authenticate(req);
   });
 
@@ -45,8 +41,8 @@ describe('passport-hawk', function() {
       method: 'GET',
       url: '/resource/4?filter=a'
     };
-    strategy.fail = function(challenge) {
-      challenge.should.eql('Bad mac');
+    strategy.error = function(challenge) {
+      challenge.message.should.eql('Bad mac');
       testDone();
     };
     strategy.authenticate(req);
@@ -68,10 +64,27 @@ describe('passport-hawk', function() {
       url: '/resource/4?filter=a'
     };
 
-    strategy.fail = function(challenge) {
-      challenge.should.eql('Unknown credentials');
+    strategy.error = function(challenge) {
+      challenge.message.should.eql('Unknown credentials');
       testDone();
     };
     strategy.authenticate(req);
   });
+
+  it('should fail with a stale request', function(testDone) {
+    var fixedHeader = 'Hawk id="dasd123", ts="1366220539", nonce="xVO62D", mac="9x+7TGN6VLRH8zX5PpwewpIzvf+mTt8m7PDQQW2NU/U="';
+    var req = {
+      headers: {
+        authorization: fixedHeader,
+        host: 'example.com:8080'
+      },
+      method: 'GET',
+      url: '/resource/4?filter=a'
+    };    
+    strategy.error = function(challenge) {
+      challenge.message.should.eql('Stale timestamp');      
+      testDone();
+    };
+    strategy.authenticate(req);
+  });  
 });


### PR DESCRIPTION
I found that in some cases (like Stale timestamp), the strategy doesn't return the correct Hawk error.
The previous behavior in a stale timestamp, the error from the strategy was an invalid login, not the real error.
