### PR TITLE
Use `strategy.fail` instead of `strategy.error`

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -70,16 +70,14 @@ Strategy.prototype.authenticate = function(req) {
 
   if(this.bewit){
     hawk.uri.authenticate(req, this.verify, {}, function (err, credentials, ext) {
-      if (err && err.isMissing) return this.fail(new Error('Missing authentication tokens'));
-      if (err && err.message === 'Missing credentials') return this.fail(new Error('Invalid authentication tokens'));
-      if (err && err.message) return this.fail(new Error(err.message)); // Return hawk error
+      if (err && err.isBoom) return this.fail(err.response.headers["WWW-Authenticate"], err.response.code);
+      if (err) return this.error(err); // unknown error
       this.success(credentials.user, ext);
     }.bind(this));
   }else{
     hawk.server.authenticate(req, this.verify, {}, function (err, credentials, ext) {
-      if (err && err.isMissing) return this.fail(new Error('Missing authentication tokens'));
-      if (err && err.message === 'Missing credentials') return this.fail(new Error('Invalid authentication tokens'));
-      if (err && err.message) return this.fail(new Error(err.message)); // Return hawk error
+      if (err && err.isBoom) return this.fail(err.response.headers["WWW-Authenticate"], err.response.code);
+      if (err) return this.error(err); // unknown error
       this.success(credentials.user, ext);
     }.bind(this));
   }

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -70,16 +70,16 @@ Strategy.prototype.authenticate = function(req) {
 
   if(this.bewit){
     hawk.uri.authenticate(req, this.verify, {}, function (err, credentials, ext) {
-      if (err && err.isMissing) return this.error(new Error('Missing authentication tokens'));
-      if (err && err.message === 'Missing credentials') return this.error(new Error('Invalid authentication tokens'));
-      if (err && err.message) return this.error(new Error(err.message)); // Return hawk error
+      if (err && err.isMissing) return this.fail(new Error('Missing authentication tokens'));
+      if (err && err.message === 'Missing credentials') return this.fail(new Error('Invalid authentication tokens'));
+      if (err && err.message) return this.fail(new Error(err.message)); // Return hawk error
       this.success(credentials.user, ext);
     }.bind(this));
   }else{
     hawk.server.authenticate(req, this.verify, {}, function (err, credentials, ext) {
-      if (err && err.isMissing) return this.error(new Error('Missing authentication tokens'));
-      if (err && err.message === 'Missing credentials') return this.error(new Error('Invalid authentication tokens'));
-      if (err && err.message) return this.error(new Error(err.message)); // Return hawk error
+      if (err && err.isMissing) return this.fail(new Error('Missing authentication tokens'));
+      if (err && err.message === 'Missing credentials') return this.fail(new Error('Invalid authentication tokens'));
+      if (err && err.message) return this.fail(new Error(err.message)); // Return hawk error
       this.success(credentials.user, ext);
     }.bind(this));
   }

--- a/test/bewit.tests.js
+++ b/test/bewit.tests.js
@@ -47,7 +47,7 @@ describe('passport-hawk with bewit', function() {
       url: '/resource/4?filter=a&bewit=' + bewit  
     };
     strategy.fail = function(challenge) {      
-      challenge.message.should.eql('Bad mac');
+      challenge.should.eql('Hawk error="Bad mac"');
       testDone();
     };
     strategy.authenticate(req);
@@ -69,7 +69,7 @@ describe('passport-hawk with bewit', function() {
     };
 
     strategy.fail = function(challenge) {
-      challenge.message.should.eql('Unknown credentials');
+      challenge.should.eql('Hawk error="Unknown credentials"');
       testDone();
     };
     strategy.authenticate(req);

--- a/test/bewit.tests.js
+++ b/test/bewit.tests.js
@@ -31,7 +31,7 @@ describe('passport-hawk with bewit', function() {
       testDone();
     };
 
-    strategy.error = function() {
+    strategy.fail = function() {
       testDone(new Error(arguments));
     };
     strategy.authenticate(req);
@@ -46,7 +46,7 @@ describe('passport-hawk with bewit', function() {
       method: 'GET',
       url: '/resource/4?filter=a&bewit=' + bewit  
     };
-    strategy.error = function(challenge) {      
+    strategy.fail = function(challenge) {      
       challenge.message.should.eql('Bad mac');
       testDone();
     };
@@ -68,7 +68,7 @@ describe('passport-hawk with bewit', function() {
       url: '/resource/4?filter=a&bewit=' + bewit  
     };
 
-    strategy.error = function(challenge) {
+    strategy.fail = function(challenge) {
       challenge.message.should.eql('Unknown credentials');
       testDone();
     };

--- a/test/header.tests.js
+++ b/test/header.tests.js
@@ -41,7 +41,7 @@ describe('passport-hawk', function() {
       method: 'GET',
       url: '/resource/4?filter=a'
     };
-    strategy.error = function(challenge) {
+    strategy.fail = function(challenge) {
       challenge.message.should.eql('Bad mac');
       testDone();
     };
@@ -64,7 +64,7 @@ describe('passport-hawk', function() {
       url: '/resource/4?filter=a'
     };
 
-    strategy.error = function(challenge) {
+    strategy.fail = function(challenge) {
       challenge.message.should.eql('Unknown credentials');
       testDone();
     };
@@ -81,7 +81,7 @@ describe('passport-hawk', function() {
       method: 'GET',
       url: '/resource/4?filter=a'
     };    
-    strategy.error = function(challenge) {
+    strategy.fail = function(challenge) {
       challenge.message.should.eql('Stale timestamp');      
       testDone();
     };

--- a/test/header.tests.js
+++ b/test/header.tests.js
@@ -42,7 +42,7 @@ describe('passport-hawk', function() {
       url: '/resource/4?filter=a'
     };
     strategy.fail = function(challenge) {
-      challenge.message.should.eql('Bad mac');
+      challenge.should.eql('Hawk error="Bad mac"');
       testDone();
     };
     strategy.authenticate(req);
@@ -65,7 +65,7 @@ describe('passport-hawk', function() {
     };
 
     strategy.fail = function(challenge) {
-      challenge.message.should.eql('Unknown credentials');
+      challenge.should.eql('Hawk error="Unknown credentials"');
       testDone();
     };
     strategy.authenticate(req);
@@ -82,7 +82,8 @@ describe('passport-hawk', function() {
       url: '/resource/4?filter=a'
     };    
     strategy.fail = function(challenge) {
-      challenge.message.should.eql('Stale timestamp');      
+      challenge.should.match(/^Hawk/);
+      challenge.should.match(/error="Stale timestamp"/);
       testDone();
     };
     strategy.authenticate(req);


### PR DESCRIPTION
See descriptions for [`strategy.fail`](https://github.com/jaredhanson/passport/blob/a06f9b239c4ffaa2cfb134a6bd13a85fbad348b5/lib/middleware/authenticate.js#L259) and [`strategy.error`](https://github.com/jaredhanson/passport/blob/a06f9b239c4ffaa2cfb134a6bd13a85fbad348b5/lib/middleware/authenticate.js#L318). Using passport-hawk in koa.js, authentication errors were causing 500 Internal Server Errors to be returned. This fix causes authentication errors to return 401 Unauthorized responses by default.

All tests pass. Works as expected with koa + koa-passport.