### PR TITLE
Allow options to be passed to hawk authenticate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
-  - 0.8
+  - '4.2'
+  - '0.12'
+sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - '4.2'
-  - '0.12'
+  - '4'
+  - '5'
 sudo: false

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -1,9 +1,9 @@
 /**
  * Module dependencies.
  */
-var passport = require('passport')
-  , util = require('util')
-  , hawk = require('hawk');
+var passport = require('passport'),
+  util = require('util'),
+  hawk = require('hawk');
 
 var xtend = require('xtend');
 
@@ -11,16 +11,15 @@ var xtend = require('xtend');
  * `Strategy` constructor.
  *
  * The HTTP Hawk authentication strategy authenticates requests based on
- * a bearer token contained in the `Authorization` header field or 
+ * a bearer token contained in the `Authorization` header field or
  * `hawk` query parameter.
  *
  * Applications must supply a `verify` callback which accepts an `id` and
- * then calls the `done` callback supplying a `credentials` object which 
- * should contains a `key` property matching the MAC, an `algorithm` 
- * property and a `user` property. 
- * If the user is not valid return false
- * `false` as the user.
- * 
+ * then calls the `done` callback supplying a `credentials` object which
+ * should contains a `key` property matching the MAC, an `algorithm`
+ * property and a `user` property.
+ * If the user is not valid return `false` as the user.
+ *
  * Examples:
  *
  *     passport.use(new HawkStrategy(
@@ -37,14 +36,14 @@ var xtend = require('xtend');
  * @api public
  */
 function Strategy(bewit, verify) {
-  if(typeof bewit == 'function'){
+  if (typeof bewit == 'function') {
     verify = bewit;
     bewit = false;
   }
-  if(typeof bewit == 'object'){
+  if (typeof bewit == 'object') {
     bewit = bewit.bewit;
   }
-  
+
   if (!verify) throw new Error('HTTP Hawk authentication strategy requires a verify function');
   this.verify = verify;
   this.bewit = bewit;
@@ -63,26 +62,20 @@ util.inherits(Strategy, passport.Strategy);
  * @param {Object} req
  * @api protected
  */
-Strategy.prototype.authenticate = function(req) {
+Strategy.prototype.authenticate = function(req, opts) {
   //express change req.url when mounting with app.use
   //this creates a new request object with url = originalUrl
   req = xtend({}, req, { url: req.originalUrl || req.url });
 
-  if(this.bewit){
-    hawk.uri.authenticate(req, this.verify, {}, function (err, credentials, ext) {
-      if (err && err.isMissing) return this.fail('Missing authentication tokens');
-      if (err && err.message === 'Missing credentials') return this.fail('Invalid authentication tokens');
-      if (err) return this.error(new Error(err.message)); // Return hawk error
-      this.success(credentials.user, ext);
-    }.bind(this));
-  }else{
-    hawk.server.authenticate(req, this.verify, {}, function (err, credentials, ext) {
-      if (err && err.isMissing) return this.fail('Missing authentication tokens');
-      if (err && err.message === 'Missing credentials') return this.fail('Invalid authentication tokens');
-      if (err && err.message) return this.error(new Error(err.message)); // Return hawk error
-      this.success(credentials.user, ext);
-    }.bind(this));
-  }
+  var authenticate = this.bewit ? 'authenticateBewit' : 'authenticate';
+  hawk.server[authenticate](req, this.verify, opts || {}, function(err, credentials, ext) {
+    if (err) {
+      if (err.isMissing) return this.fail('Missing authentication tokens');
+      if (err.message === 'Missing credentials') return this.fail('Invalid authentication tokens');
+      return this.error(new Error(err.message)); // Return hawk error
+    }
+    return this.success(credentials.user, ext);
+  }.bind(this));
 };
 
 /**

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -71,9 +71,7 @@ Strategy.prototype.authenticate = function(req, opts) {
   hawk.server[authenticate](req, this.verify, opts || {}, function(err, credentials, ext) {
     if (err) {
       if (err.isMissing) return this.fail('Missing authentication tokens');
-      if (err.message === 'Unknown credentials' || err.message === 'Invalid credentials')
-        return this.fail('Invalid authentication tokens');
-      return this.error(new Error(err.message)); // Return hawk error
+      return this.error(err); // Return hawk error
     }
     return this.success(credentials.user, ext);
   }.bind(this));

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -71,7 +71,8 @@ Strategy.prototype.authenticate = function(req, opts) {
   hawk.server[authenticate](req, this.verify, opts || {}, function(err, credentials, ext) {
     if (err) {
       if (err.isMissing) return this.fail('Missing authentication tokens');
-      if (err.message === 'Missing credentials') return this.fail('Invalid authentication tokens');
+      if (err.message === 'Unknown credentials' || err.message === 'Invalid credentials')
+        return this.fail('Invalid authentication tokens');
       return this.error(new Error(err.message)); // Return hawk error
     }
     return this.success(credentials.user, ext);

--- a/package.json
+++ b/package.json
@@ -17,12 +17,12 @@
   "author": "José F. Romaniello <jfromaniello@gmail.com> (http://joseoncode.com)",
   "license": "MIT",
   "dependencies": {
-    "hawk": "^3.1.0",
+    "hawk": "^4.0.1",
     "passport": "^0.3.0",
     "xtend": "^4.0.1"
   },
   "devDependencies": {
     "mocha": "^2.3.3",
-    "should": "^7.1.1"
+    "should": "^8.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Passport strategy for the Hawk authentication schema.",
   "main": "lib/strategy.js",
   "scripts": {
-    "test": "mocha --require should -R spec"
+    "test": "mocha"
   },
   "repository": {
     "type": "git",
@@ -17,12 +17,12 @@
   "author": "José F. Romaniello <jfromaniello@gmail.com> (http://joseoncode.com)",
   "license": "MIT",
   "dependencies": {
-    "hawk": "~2.3.1",
-    "passport": "~0.2.1",
-    "xtend": "2.0.x"
+    "hawk": "^3.1.0",
+    "passport": "^0.3.0",
+    "xtend": "^4.0.1"
   },
   "devDependencies": {
-    "should": "1.2.x",
-    "mocha": "1.9.x"
+    "mocha": "^2.3.3",
+    "should": "^7.1.1"
   }
 }

--- a/test/bewit.tests.js
+++ b/test/bewit.tests.js
@@ -1,5 +1,6 @@
 var HawkStrategy = require('../lib/strategy'),
-  Hawk = require('hawk');
+  Hawk = require('hawk'),
+  should = require('should');
 
 var credentials = {
   key: 'abcd',
@@ -8,8 +9,8 @@ var credentials = {
   id: 'dasd123'
 };
 
-var strategy = new HawkStrategy({bewit: true}, function(id, done) {
-  if(id === credentials.id) return done(null, credentials);
+var strategy = new HawkStrategy({ bewit: true }, function(id, done) {
+  if (id === credentials.id) return done(null, credentials);
   return done(null, null);
 });
 
@@ -17,13 +18,16 @@ var strategy = new HawkStrategy({bewit: true}, function(id, done) {
 describe('passport-hawk with bewit', function() {
 
   it('can authenticate a request with a correct header', function(testDone) {
-    var bewit = Hawk.uri.getBewit('http://example.com:8080/resource/4?filter=a', { credentials: credentials, ttlSec: 60 * 5});
+    var bewit = Hawk.uri.getBewit('http://example.com:8080/resource/4?filter=a', {
+      credentials: credentials,
+      ttlSec: 60 * 5
+    });
     var req = {
       headers: {
         host: 'example.com:8080'
       },
       method: 'GET',
-      url: '/resource/4?filter=a&bewit=' + bewit  
+      url: '/resource/4?filter=a&bewit=' + bewit
     };
 
     strategy.success = function(user) {
@@ -38,15 +42,18 @@ describe('passport-hawk with bewit', function() {
   });
 
   it('should properly fail with correct challenge code when using different url', function(testDone) {
-    var bewit = Hawk.uri.getBewit('http://example.com:8080/resource/4?filter=a' + bewit, { credentials: credentials, ttlSec: 60 * 5});
+    var bewit = Hawk.uri.getBewit('http://example.com:8080/resource/4?filter=a' + bewit, {
+      credentials: credentials,
+      ttlSec: 60 * 5
+    });
     var req = {
       headers: {
         host: 'example.com:8080'
       },
       method: 'GET',
-      url: '/resource/4?filter=a&bewit=' + bewit  
+      url: '/resource/4?filter=a&bewit=' + bewit
     };
-    strategy.error = function(challenge) {      
+    strategy.error = function(challenge) {
       challenge.message.should.eql('Bad mac');
       testDone();
     };
@@ -54,18 +61,21 @@ describe('passport-hawk with bewit', function() {
   });
 
   it('should call done with false when the id doesnt exist', function(testDone) {
-    var bewit = Hawk.uri.getBewit('http://example.com:8080/foobar', { credentials: {
+    var bewit = Hawk.uri.getBewit('http://example.com:8080/foobar', {
+      credentials: {
         id: '321321',
         key: 'dsa',
         algorithm: 'sha256'
-      }, ttlSec: 60 * 5});
-  
+      },
+      ttlSec: 60 * 5
+    });
+
     var req = {
       headers: {
         host: 'example.com:8080'
       },
       method: 'GET',
-      url: '/resource/4?filter=a&bewit=' + bewit  
+      url: '/resource/4?filter=a&bewit=' + bewit
     };
 
     strategy.error = function(challenge) {
@@ -76,7 +86,7 @@ describe('passport-hawk with bewit', function() {
   });
 
   it('should call fail when url doesnt have a bewit', function(testDone) {
-  
+
     var req = {
       headers: {
         host: 'example.com:8080'

--- a/test/header.tests.js
+++ b/test/header.tests.js
@@ -1,5 +1,6 @@
 var HawkStrategy = require('../lib/strategy'),
-  Hawk = require('hawk');
+  Hawk = require('hawk'),
+  should = require('should');
 
 var credentials = {
   key: 'abcd',
@@ -9,13 +10,13 @@ var credentials = {
 };
 
 var strategy = new HawkStrategy(function(id, done) {
-  if(id === credentials.id) return done(null, credentials);
+  if (id === credentials.id) return done(null, credentials);
   return done(null, null);
 });
 
 describe('passport-hawk', function() {
   it('can authenticate a request with a correct header', function(testDone) {
-    var header = Hawk.client.header('http://example.com:8080/resource/4?filter=a', 'GET', { credentials: credentials });  
+    var header = Hawk.client.header('http://example.com:8080/resource/4?filter=a', 'GET', { credentials: credentials });
     var req = {
       headers: {
         authorization: header.field,
@@ -23,7 +24,7 @@ describe('passport-hawk', function() {
       },
       method: 'GET',
       url: '/resource/4?filter=a'
-    };    
+    };
     strategy.success = function(user) {
       user.should.eql('tito');
       testDone();
@@ -32,7 +33,7 @@ describe('passport-hawk', function() {
   });
 
   it('should properly fail with correct challenge code when using different url', function(testDone) {
-    var header = Hawk.client.header('http://example.com:8080/resource/4?filter=a', 'GET', { credentials: credentials });    
+    var header = Hawk.client.header('http://example.com:8080/resource/4?filter=a', 'GET', { credentials: credentials });
     var req = {
       headers: {
         authorization: header.field,
@@ -80,11 +81,29 @@ describe('passport-hawk', function() {
       },
       method: 'GET',
       url: '/resource/4?filter=a'
-    };    
+    };
     strategy.error = function(challenge) {
-      challenge.message.should.eql('Stale timestamp');      
+      challenge.message.should.eql('Stale timestamp');
       testDone();
     };
     strategy.authenticate(req);
-  });  
+  });
+
+  it('can authenticate a request with options', function(testDone) {
+    var header = Hawk.client.header('https://example.com/resource/4?filter=a', 'GET', { credentials: credentials });
+    var req = {
+      headers: {
+        authorization: header.field,
+        host: 'example.com:3000'
+      },
+      method: 'GET',
+      url: '/resource/4?filter=a'
+    };
+    var opts = { port: 443 };
+    strategy.success = function(user) {
+      user.should.eql('tito');
+      testDone();
+    };
+    strategy.authenticate(req, opts);
+  });
 });


### PR DESCRIPTION
My main use case is with Heroku, where the url is `https` but that's translated to a different port internally. See added test for example.

Also
- update all deps
- DRY call to hawk authenticate
- add test for options
- apply consistent formatting

_Note:_
`hawk.uri.authenticate` === `hawk.server.authenticateBewit`
per https://github.com/hueniverse/hawk/blob/master/lib/index.js#L11-L14